### PR TITLE
Fix to sensor activate callback

### DIFF
--- a/sensors_vhal.cpp
+++ b/sensors_vhal.cpp
@@ -290,7 +290,8 @@ int SensorDevice::sensor_device_poll_event_locked() {
 
         int handle = get_handle_from_type(sensor_type);
         sensor_data_count[handle]++;
-        switch (sensor_type) {
+#ifdef DEBUG_SENSOR_DATA
+	switch (sensor_type) {
             case SENSOR_TYPE_ACCELEROMETER:
             case SENSOR_TYPE_GYROSCOPE:
             case SENSOR_TYPE_MAGNETIC_FIELD:
@@ -319,7 +320,7 @@ int SensorDevice::sensor_device_poll_event_locked() {
                 }
                 break;
         }
-
+#endif
         last_sensor_time[handle] = new_sensor_events_ptr->timestamp;
         break;
     }
@@ -425,13 +426,11 @@ int SensorDevice::sensor_device_activate(int handle, int enabled) {
     m_sensor_config_status[handle].sensor_type = id;
     m_sensor_config_status[handle].enabled     = enabled;
     ALOGI("activate: sensor type=%d, enabled=%d, handle=%s(%d)", id, enabled, get_name_from_handle(handle), handle);
-    if (!enabled) {
-        int ret = sensor_device_send_config_msg(&m_sensor_config_status[handle], sizeof(sensor_config_msg_t));
-        if (ret < 0) {
-            ALOGE("could not send activate command: %s", strerror(-ret));
-            m_mutex.unlock();
-            return -errno;
-        }
+    int ret = sensor_device_send_config_msg(&m_sensor_config_status[handle], sizeof(sensor_config_msg_t));
+    if (ret < 0) {
+        ALOGE("could not send activate command: %s", strerror(-ret));
+        m_mutex.unlock();
+        return -errno;
     }
     m_mutex.unlock();
     return 0;


### PR DESCRIPTION
Removed the check to send sensor activate/de-activate.
Disabled sensor data logs as they are too frequent and also can be
found in dumpsys.

Tracked-On: OAM-100318
Signed-off-by: Jaikrishna Nemallapudi <nemallapudi.jaikrishna@intel.com>