### PR TITLE
Add GTest support for sensors_vhal APIs

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -37,3 +37,5 @@ LOCAL_SRC_FILES := \
 		sock_utils/sock_server.cpp \
 		sock_utils/sock_utils.cpp
 include $(BUILD_SHARED_LIBRARY)
+
+include $(call all-makefiles-under, $(LOCAL_PATH))

--- a/Gtest/Android.mk
+++ b/Gtest/Android.mk
@@ -1,0 +1,33 @@
+LOCAL_PATH:= $(call my-dir)
+include $(CLEAR_VARS)
+
+LOCAL_LDLIBS += -landroid -llog
+LOCAL_CFLAGS += -std=c++11
+LOCAL_CFLAGS += -Wno-unused-parameter -Wno-macro-redefined -fexceptions
+
+LOCAL_MODULE_TAGS:= optional
+
+LOCAL_SHARED_LIBRARIES += liblog libcutils libutils sensors.cic_cloud
+LOCAL_MULTILIB := 64
+LOCAL_VENDOR_MODULE := true
+LOCAL_STATIC_LIBRARIES += libgtest_main libgtest libgmock
+
+LOCAL_CPPFLAGS := $(LOG_FLAGS) $(WARNING_LEVEL) $(DEBUG_FLAGS) $(VERSION_FLAGS)
+
+LOCAL_C_INCLUDES += \
+    $(LOCAL_PATH) \
+    $(LOCAL_PATH)/../ \
+    $(LOCAL_PATH)/../sock_utils/include \
+    $(LOCAL_PATH)/../../../external/googletest/googletest/include
+
+LOCAL_SRC_FILES := \
+    main.cpp \
+    sensors_client.cpp \
+    sensors_fixture.cpp \
+    ../sock_utils/sock_utils.cpp \
+    ../sock_utils/sock_client.cpp \
+    ../sock_utils/sock_server.cpp
+
+LOCAL_MODULE:= SensorsTest
+
+include $(BUILD_EXECUTABLE)

--- a/Gtest/main.cpp
+++ b/Gtest/main.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "sensors_fixture.h"
+
+int main(int argc, char **argv) {
+    setenv("TERM", "xterm-color", true);
+    testing::InitGoogleTest(&argc, argv);
+
+    return RUN_ALL_TESTS();
+}
+

--- a/Gtest/sensors_client.cpp
+++ b/Gtest/sensors_client.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _SENSORS_CLIENT_H
+#define _SENSORS_CLIENT_H
+
+#include <log/log.h>
+#include "sensors_client.h"
+#include "sock_utils.h"
+
+#define LOG_TAG "SensorsClient"
+
+using namespace std;
+#define FAKE_DATA_LEN 20
+
+SensorsClient::SensorsClient() {
+    char buf[PROPERTY_VALUE_MAX] = {'\0'};
+    int sensor_port = SENSOR_VHAL_PORT;
+    if (property_get(SENSOR_VHAL_PORT_PROP, buf, NULL) > 0) {
+        sensor_port = atoi(buf);
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(20)); //Make sure server init complete.
+    std::string SocketPath;
+    char build_id_buf[PROPERTY_VALUE_MAX] = {'\0'};
+    property_get("ro.boot.container.id", build_id_buf, "");
+    std::string sock_path = "/ipc/sensors-socket";
+    sock_path.append(build_id_buf);
+    char *k8s_env_value = getenv("K8S_ENV");
+    SocketPath = (k8s_env_value != NULL && !strcmp(k8s_env_value, "true"))
+			                ? "/conn/sensors-socket" : sock_path.c_str();
+    if (property_get(SENSOR_SOCK_TYPE_PROP, buf, NULL) > 0) {
+        if (!strcmp(buf, "INET")) {
+            m_client_sock = new SockClient((char*)LOCAL_VHAL_IP, sensor_port, 1.0f);
+        } else {
+            m_client_sock = new SockClient(SocketPath.c_str(), 1.0f);
+        }
+    } else {
+        m_client_sock = new SockClient(SocketPath.c_str(), 1.0f);
+    }
+    m_client_sock->register_connected_callback(std::bind(&SensorsClient::vhal_connected_callback, this, std::placeholders::_1));
+    m_client_sock->register_disconnected_callback(std::bind(&SensorsClient::vhal_disconnected_callback, this, std::placeholders::_1));
+    m_client_sock->register_listener_callback(std::bind(&SensorsClient::vhal_message_callback, this, std::placeholders::_1));
+    m_client_sock->start();
+}
+
+SensorsClient::~SensorsClient() {
+    m_connected = false;
+    if(m_client_sock) {
+        delete m_client_sock;
+        m_client_sock = nullptr;
+    }
+}
+
+void SensorsClient::vhal_connected_callback(SockClient *sock) {
+    ALOGI("connected to server successfully: %s, %d", sock->get_ip(), sock->get_port());
+    m_connected = true;
+}
+
+void SensorsClient::vhal_disconnected_callback(SockClient *sock) {
+    ALOGI("disconnected to server");
+    (void)(sock);
+    m_connected = false;
+}
+
+void SensorsClient::vhal_message_callback(SockClient* client) {
+    sensor_config_msg_t sensor_ctrl_msg;
+    char* pointer = (char*)(&sensor_ctrl_msg);
+    int len = sizeof(sensor_config_msg_t);
+    int retry_count = 30;
+    int left_size = len;
+    while (left_size > 0) {
+        int ret = client->recv_data(pointer, left_size);
+        if (ret <= 0) {
+            if (errno == EINTR || errno == EWOULDBLOCK || errno == EAGAIN) {
+                usleep(1000);
+                if ((retry_count--) < 0) {
+                    ALOGW("[timeout], failed to recv sensor config data from vhal:target: %d, recved len: %d, [%s], \n", len, len - left_size, strerror(errno));
+                    return;
+                }
+                continue;
+            } else {
+                ALOGW("failed to recv sensor config data from vhal: %s\n", strerror(errno));
+                return;
+            }
+        }
+        left_size -= ret;
+        pointer += ret;
+    }
+
+    ALOGI("receive config message from sensor vhal, sensor type: %d, enabled: %d, sample period: %d",
+        sensor_ctrl_msg.sensor_type, sensor_ctrl_msg.enabled, sensor_ctrl_msg.sample_period);
+    process_config_info(sensor_ctrl_msg);
+}
+
+int SensorsClient::get_payload_len(int sensor_type) {
+    int payload_len = 0;
+    switch (sensor_type) {
+        case SENSOR_TYPE_ACCELEROMETER:
+        case SENSOR_TYPE_GYROSCOPE:
+        case SENSOR_TYPE_MAGNETIC_FIELD:
+            payload_len = 3 * sizeof(float);
+            break;
+        case SENSOR_TYPE_ACCELEROMETER_UNCALIBRATED:
+        case SENSOR_TYPE_GYROSCOPE_UNCALIBRATED:
+        case SENSOR_TYPE_MAGNETIC_FIELD_UNCALIBRATED:
+            payload_len = 6 * sizeof(float);
+            break;
+        case SENSOR_TYPE_LIGHT:
+        case SENSOR_TYPE_PROXIMITY:
+        case SENSOR_TYPE_AMBIENT_TEMPERATURE:
+            payload_len = 1 * sizeof(float);
+            break;
+        default:
+            payload_len = 0;
+            ALOGW("unsupported sensor type %d", sensor_type);
+            break;
+    }
+    return payload_len;
+}
+
+void SensorsClient::process_config_info(sensor_config_msg_t& cfg) {
+    for(int i = 0; i < FAKE_DATA_LEN; i++) {
+        aic_sensors_event_t *fake_data = nullptr;
+        size_t pay_load_len = get_payload_len(cfg.sensor_type);
+        if(pay_load_len == 0) {
+            ALOGW("unsupported sensor type %d", cfg.sensor_type);
+            break;
+        }
+        size_t packet_size = sizeof(aic_sensors_event_t) + pay_load_len;
+        fake_data = (aic_sensors_event_t *)new char[packet_size];
+        memset(fake_data, 0, packet_size);  //Fill faka data. all default to 0
+        fake_data->type = cfg.sensor_type;
+        m_client_sock->send_data(fake_data, packet_size);
+        usleep(cfg.sample_period * 1000);
+        delete fake_data;
+        fake_data = nullptr;
+    }
+}
+
+#endif

--- a/Gtest/sensors_client.h
+++ b/Gtest/sensors_client.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <log/log.h>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <algorithm>
+#include "sock_utils.h"
+#include "sensors_vhal.h"
+
+#define LOCAL_VHAL_IP "127.0.0.1"
+
+using namespace std;
+class SensorsClient {
+public:
+    SensorsClient();
+    ~SensorsClient();
+    bool is_connected() { return m_connected; }
+
+private:
+    void vhal_connected_callback(SockClient *sock);
+    void vhal_disconnected_callback(SockClient *sock);
+    void vhal_message_callback(SockClient* client);
+    int get_payload_len(int sensor_type);
+    void process_config_info(sensor_config_msg_t& cfg);
+
+private:
+    bool m_connected = false;
+    SockClient* m_client_sock = nullptr;
+};

--- a/Gtest/sensors_fixture.cpp
+++ b/Gtest/sensors_fixture.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <thread>
+#include <chrono>
+#include "sensors_fixture.h"
+
+#define SUPPORTED_SENSORS_NUMBER 9
+#define INVALID_SENSOR_TYPE     -1
+#define INVALID_SENSOR_HANDLE   -1
+#define ENABLED                  1
+#define DISABLED                 0
+#define UNUSED_FLAG             -1
+#define SAMPLE_PERIOD_NS         50*1000000
+#define AT_LEAST_ONE_EVENT       1
+#define SUCCESS                  0
+#define FAILED                   -EINVAL
+
+#define LOG_TAG "SensorsFixture"
+
+extern int sensor_poll_events(struct sensors_poll_device_t* dev0, sensors_event_t* data, int count);
+extern int sensor_activate(struct sensors_poll_device_t* dev0, int handle, int enabled);
+extern int sensor_batch(struct sensors_poll_device_1* dev0, int handle, int flags __unused, \
+                        int64_t sampling_period_ns, int64_t max_report_latency_ns __unused);
+extern int sensor_set_delay(struct sensors_poll_device_t* dev0, int handle __unused, int64_t ns);
+extern int sensor_flush(struct sensors_poll_device_1* dev0, int handle);
+extern int sensor_close(struct hw_device_t* dev0);
+
+SensorsFixture::SensorsFixture() {
+    m_test_dev = new SensorDevice();
+}
+
+SensorsFixture::~SensorsFixture() {
+    if(m_test_dev) {
+        delete m_test_dev;
+        m_test_dev = nullptr;
+    }
+}
+
+TEST_F(SensorsFixture, SocketConnectionCheck)
+{
+    this_thread::sleep_for(std::chrono::milliseconds(2000)); //Make sure client connected to server
+    ASSERT_TRUE(m_sensors_client.is_connected());
+}
+
+TEST_F(SensorsFixture, SensorsTypeCheck)
+{
+    ASSERT_EQ(INVALID_SENSOR_HANDLE, m_test_dev->get_handle_from_type(INVALID_SENSOR_TYPE));
+    ASSERT_EQ(ID_ACCELEROMETER, m_test_dev->get_handle_from_type(SENSOR_TYPE_ACCELEROMETER));
+    ASSERT_EQ(ID_GYROSCOPE, m_test_dev->get_handle_from_type(SENSOR_TYPE_GYROSCOPE));
+    ASSERT_EQ(ID_MAGNETIC_FIELD, m_test_dev->get_handle_from_type(SENSOR_TYPE_MAGNETIC_FIELD));
+    ASSERT_EQ(ID_ACCELEROMETER_UNCALIBRATED, m_test_dev->get_handle_from_type(SENSOR_TYPE_ACCELEROMETER_UNCALIBRATED));
+    ASSERT_EQ(ID_GYROSCOPE_UNCALIBRATED, m_test_dev->get_handle_from_type(SENSOR_TYPE_GYROSCOPE_UNCALIBRATED));
+    ASSERT_EQ(ID_MAGNETIC_FIELD_UNCALIBRATED, m_test_dev->get_handle_from_type(SENSOR_TYPE_MAGNETIC_FIELD_UNCALIBRATED));
+    ASSERT_EQ(ID_LIGHT, m_test_dev->get_handle_from_type(SENSOR_TYPE_LIGHT));
+    ASSERT_EQ(ID_PROXIMITY, m_test_dev->get_handle_from_type(SENSOR_TYPE_PROXIMITY));
+    ASSERT_EQ(ID_TEMPERATURE, m_test_dev->get_handle_from_type(SENSOR_TYPE_AMBIENT_TEMPERATURE));
+}
+
+TEST_F(SensorsFixture, ActivateMagneticFiledEvents)
+{
+    ASSERT_EQ(FAILED, sensor_activate((sensors_poll_device_t*)m_test_dev, INVALID_SENSOR_HANDLE, ENABLED));
+    ASSERT_EQ(SUCCESS, sensor_activate((sensors_poll_device_t*)m_test_dev, ID_MAGNETIC_FIELD, ENABLED));
+}
+
+TEST_F(SensorsFixture, BatchMagneticFiledEvents)
+{
+    ASSERT_EQ(FAILED, sensor_batch((struct sensors_poll_device_1*)m_test_dev, INVALID_SENSOR_HANDLE, UNUSED_FLAG, SAMPLE_PERIOD_NS, UNUSED_FLAG));
+    ASSERT_EQ(SUCCESS, sensor_batch((struct sensors_poll_device_1*)m_test_dev, ID_MAGNETIC_FIELD, UNUSED_FLAG, SAMPLE_PERIOD_NS, UNUSED_FLAG));
+}
+
+TEST_F(SensorsFixture, SetDelayMagneticFiledEvents)
+{
+    ASSERT_EQ(FAILED, sensor_set_delay((sensors_poll_device_t*)m_test_dev, INVALID_SENSOR_HANDLE, SAMPLE_PERIOD_NS));
+    ASSERT_EQ(SUCCESS, sensor_set_delay((sensors_poll_device_t*)m_test_dev, ID_MAGNETIC_FIELD, SAMPLE_PERIOD_NS));
+}
+
+TEST_F(SensorsFixture, PollEventsWithZeroCount)
+{
+    ASSERT_EQ(SUCCESS, sensor_activate((sensors_poll_device_t*)m_test_dev, ID_MAGNETIC_FIELD, ENABLED));
+    ASSERT_EQ(SUCCESS, sensor_batch((struct sensors_poll_device_1*)m_test_dev, ID_MAGNETIC_FIELD, UNUSED_FLAG, SAMPLE_PERIOD_NS, UNUSED_FLAG));
+    ASSERT_EQ(FAILED, sensor_poll_events((sensors_poll_device_t*)m_test_dev, m_data, 0));
+}
+
+TEST_F(SensorsFixture, PollEventsWithNegativeCount)
+{
+    ASSERT_EQ(SUCCESS, sensor_activate((sensors_poll_device_t*)m_test_dev, ID_MAGNETIC_FIELD, ENABLED));
+    ASSERT_EQ(SUCCESS, sensor_batch((struct sensors_poll_device_1*)m_test_dev, ID_MAGNETIC_FIELD, UNUSED_FLAG, SAMPLE_PERIOD_NS, UNUSED_FLAG));
+    ASSERT_EQ(FAILED, sensor_poll_events((sensors_poll_device_t*)m_test_dev, m_data, -DATA_NUM));
+}
+
+TEST_F(SensorsFixture, PollEventsWithValidCount)
+{
+    ASSERT_EQ(SUCCESS, sensor_activate((sensors_poll_device_t*)m_test_dev, ID_MAGNETIC_FIELD, ENABLED));
+    ASSERT_EQ(SUCCESS, sensor_batch((struct sensors_poll_device_1*)m_test_dev, ID_MAGNETIC_FIELD, UNUSED_FLAG, SAMPLE_PERIOD_NS, UNUSED_FLAG));
+    ASSERT_EQ(AT_LEAST_ONE_EVENT, sensor_poll_events((sensors_poll_device_t*)m_test_dev, m_data, DATA_NUM));
+}
+
+TEST_F(SensorsFixture, FlushMagneticFiledEvents)
+{
+    ASSERT_EQ(SUCCESS, sensor_activate((sensors_poll_device_t*)m_test_dev, ID_MAGNETIC_FIELD, ENABLED));
+    ASSERT_EQ(SUCCESS, sensor_batch((struct sensors_poll_device_1*)m_test_dev, ID_MAGNETIC_FIELD, UNUSED_FLAG, SAMPLE_PERIOD_NS, UNUSED_FLAG));
+    ASSERT_LE(AT_LEAST_ONE_EVENT, sensor_poll_events((sensors_poll_device_t*)m_test_dev, m_data, DATA_NUM));
+    ASSERT_EQ(SUCCESS, sensor_flush((struct sensors_poll_device_1*)m_test_dev, ID_MAGNETIC_FIELD));
+}
+
+TEST_F(SensorsFixture, SensorCloseCheck)
+{
+    ASSERT_EQ(SUCCESS, sensor_close((struct hw_device_t*)m_test_dev));
+}

--- a/Gtest/sensors_fixture.h
+++ b/Gtest/sensors_fixture.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _SENSOR_FIXTURE_H
+#define _SENSOR_FIXTURE_H
+
+#include "gtest/gtest.h"
+#include "sensors_client.h"
+#define DATA_NUM  5
+
+class SensorsFixture : public ::testing::Test {
+public:
+    SensorsFixture();
+    ~SensorsFixture();
+    sensors_event_t m_data[DATA_NUM];
+    SensorsClient m_sensors_client;
+    SensorDevice *m_test_dev;
+};
+
+#endif

--- a/sensors_vhal.cpp
+++ b/sensors_vhal.cpp
@@ -598,7 +598,7 @@ void SensorDevice::client_connected_callback(SockServer* sock, sock_client_proxy
     }
 }
 
-static int sensor_poll_events(struct sensors_poll_device_t* dev0, sensors_event_t* data, int count) {
+int sensor_poll_events(struct sensors_poll_device_t* dev0, sensors_event_t* data, int count) {
     if (count <= 0) {
         return -EINVAL;
     }
@@ -606,27 +606,27 @@ static int sensor_poll_events(struct sensors_poll_device_t* dev0, sensors_event_
     return dev->sensor_device_poll(data, count);
 }
 
-static int sensor_activate(struct sensors_poll_device_t* dev0, int handle, int enabled) {
+int sensor_activate(struct sensors_poll_device_t* dev0, int handle, int enabled) {
     SensorDevice* dev = (SensorDevice*)dev0;
     return dev->sensor_device_activate(handle, enabled);
 }
 
-static int sensor_batch(struct sensors_poll_device_1* dev0, int handle, int flags __unused, int64_t sampling_period_ns, int64_t max_report_latency_ns __unused) {
+int sensor_batch(struct sensors_poll_device_1* dev0, int handle, int flags __unused, int64_t sampling_period_ns, int64_t max_report_latency_ns __unused) {
     SensorDevice* dev = (SensorDevice*)dev0;
     return dev->sensor_device_batch(handle, sampling_period_ns);
 }
 
-static int sensor_set_delay(struct sensors_poll_device_t* dev0, int handle __unused, int64_t ns) {
+int sensor_set_delay(struct sensors_poll_device_t* dev0, int handle __unused, int64_t ns) {
     SensorDevice* dev = (SensorDevice*)dev0;
     return dev->sensor_device_set_delay(handle, ns);
 }
 
-static int sensor_flush(struct sensors_poll_device_1* dev0, int handle) {
+int sensor_flush(struct sensors_poll_device_1* dev0, int handle) {
     SensorDevice* dev = (SensorDevice*)dev0;
     return dev->sensor_device_flush(handle);
 }
 
-static int sensor_close(struct hw_device_t* dev0) {
+int sensor_close(struct hw_device_t* dev0) {
     ALOGI("close sensor device");
     SensorDevice* dev = (SensorDevice*)dev0;
     delete dev;

--- a/sensors_vhal.h
+++ b/sensors_vhal.h
@@ -124,6 +124,7 @@ public:
     int sensor_device_flush(int handle);
     int sensor_device_set_delay(int handle, int64_t ns);
     int sensor_device_batch(int sensor_handle, int64_t sampling_period_ns);
+    int get_handle_from_type(int sensor_type);
 
 private:
     uint32_t m_flush_count[MAX_NUM_SENSORS];
@@ -150,7 +151,6 @@ private:
     int sensor_device_pick_pending_event_locked(sensors_event_t* event);
     void sensor_event_callback(SockServer* sock, sock_client_proxy_t* client);
     void client_connected_callback(SockServer* sock, sock_client_proxy_t* client);
-    int get_handle_from_type(int sensor_type);
     int get_payload_len(int sensor_type);
     const char* get_name_from_handle(int id);
 };


### PR DESCRIPTION
1. Remove static modifier to exposed interface to run unit test
2. Add a SensorsHelper class to help implement unit test.
3. Add unit test case for sensors_vhal in GTest